### PR TITLE
Check the connection config for database name

### DIFF
--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -17,7 +17,7 @@ module Apartment
 
         database = @processor.call(request)
 
-        if database && Apartment::Tenant.current != database
+        if database && Apartment.connection_config[:database] != database
           Apartment::Tenant.switch!(database)
         end
 


### PR DESCRIPTION
Previously, apartment would try to connect to the database to determine the "current" database. However, if the database doesn't exist, this throws an error. This fix examines the connection configuration for the database name directly instead of attempting  to make a connection.