### PR TITLE
Adding a mandatory database reset before switching

### DIFF
--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -18,6 +18,7 @@ module Apartment
         database = @processor.call(request)
 
         if database && Apartment.connection_config[:database] != database
+          Apartment::Tenant.reset
           Apartment::Tenant.switch!(database)
         end
 


### PR DESCRIPTION
Upon trying to switch to a non-existant tenant/database, the non-existant database information is preserved throughout the next request and breaks future calls. This reset ensures that, before trying to switch tenants, that the database configuration is reset to the default before every switch occurs.